### PR TITLE
Clarify MIT and third‑party licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2025 ProjectMobius contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+For details on third-party licenses and the complete repository terms,
+see LICENSE.md.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -7,6 +7,10 @@ This repository includes four main components, each governed by its own licensin
 3. **Node.js Server**  
 4. **Third-Party Libraries & Assets** (included under `Source/`)
 
+### Licensing Overview
+
+ProjectMobius's own source code (the Node.js server, Qt application sources, and all custom Unreal Engine modules and assets) is released under the MIT License. Unreal Engine, Qt runtime libraries, and other bundled third-party libraries or imported assets remain under their respective licenses as detailed below.
+
 ---
 
 ## 1. Unreal Engine 5.5 Project


### PR DESCRIPTION
## Summary
- clarify which parts of the project fall under the MIT license
- add a short MIT `LICENSE` file with a pointer to `LICENSE.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'googlemock')*

------
https://chatgpt.com/codex/tasks/task_e_6840e310b98883258cc152e00d4f0b9b