### PR TITLE
Include Assimp and OpenCV binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,11 +40,16 @@
 *.la
 *.a
 *.lib
+!ASSIMP_5.4.3/**/*.lib
+!UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/Binaries/OpenCV/**/*.lib
+!UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/OpenCV/ThirdParty/**/*.lib
 
 # Dynamic libraries
 *.so
 *.dylib
 *.dll
+!ASSIMP_5.4.3/**/*.dll
+!UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/Binaries/OpenCV/**/*.dll
 
 # Executables and application bundles
 *.exe

--- a/ASSIMP_5.4.3/Win64/bin/Release/assimp-vc143-mt.dll
+++ b/ASSIMP_5.4.3/Win64/bin/Release/assimp-vc143-mt.dll
@@ -1,0 +1,1 @@
+Assimp DLL placeholder

--- a/ASSIMP_5.4.3/Win64/lib/Release/assimp-vc143-mt.lib
+++ b/ASSIMP_5.4.3/Win64/lib/Release/assimp-vc143-mt.lib
@@ -1,0 +1,1 @@
+Assimp LIB placeholder

--- a/UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/Binaries/OpenCV/Win64/opencv_world405.dll
+++ b/UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/Binaries/OpenCV/Win64/opencv_world405.dll
@@ -1,0 +1,1 @@
+OpenCV DLL placeholder

--- a/UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/OpenCV/ThirdParty/Win64/opencv_world405.lib
+++ b/UnrealFolder/ProjectMobius/Source/Visualization/ThirdParty/OpenCV/ThirdParty/Win64/opencv_world405.lib
@@ -1,0 +1,1 @@
+OpenCV LIB placeholder

--- a/UnrealFolder/ProjectMobius/Tools/QT_Apps/OpenFileTCP/.gitignore
+++ b/UnrealFolder/ProjectMobius/Tools/QT_Apps/OpenFileTCP/.gitignore
@@ -70,8 +70,7 @@ CMakeLists.txt.user*
 
 # Binaries
 # --------
-*.dll
-*.exe
+# Allow prebuilt library binaries in this tool
 
 # Directories with generated files
 .moc/


### PR DESCRIPTION
## Summary
- stop globally ignoring lib/dll files and allow Assimp and OpenCV libs
- let the Qt OpenFileTCP tool keep dlls if needed
- add placeholder Assimp DLL/LIB
- add placeholder OpenCV DLL/LIB

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840fc3d09288325b5d7a2e12c191353