### PR TITLE
Remove MIT license from headers

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius.Target.cs
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius.Target.cs
@@ -1,28 +1,4 @@
-/**
- * MIT License
- * Copyright (c) 2025 ProjectMobius contributors
- * Nicholas R. Harding and Peter Thompson
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- *      The above copyright notice and this permission notice shall be included in
- *      all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-
+// Copyright Epic Games, Inc. All Rights Reserved.
 using UnrealBuildTool;
 using System.Collections.Generic;
 

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.Build.cs
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.Build.cs
@@ -1,28 +1,4 @@
-/**
- * MIT License
- * Copyright (c) 2025 ProjectMobius contributors
- * Nicholas R. Harding and Peter Thompson
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- *      The above copyright notice and this permission notice shall be included in
- *      all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-
+// Copyright Epic Games, Inc. All Rights Reserved.
 using System;
 using UnrealBuildTool;
 using System.IO;

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.cpp
@@ -1,28 +1,4 @@
-/**
- * MIT License
- * Copyright (c) 2025 ProjectMobius contributors
- * Nicholas R. Harding and Peter Thompson
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- *      The above copyright notice and this permission notice shall be included in
- *      all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-
+// Copyright Epic Games, Inc. All Rights Reserved.
 #include "ProjectMobius.h"
 #include "Modules/ModuleManager.h"
 

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/ProjectMobius.h
@@ -1,28 +1,4 @@
-/**
- * MIT License
- * Copyright (c) 2025 ProjectMobius contributors
- * Nicholas R. Harding and Peter Thompson
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- *      The above copyright notice and this permission notice shall be included in
- *      all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-
+// Copyright Epic Games, Inc. All Rights Reserved.
 #pragma once
 
 #include "CoreMinimal.h"

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobiusEditor.Target.cs
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobiusEditor.Target.cs
@@ -1,28 +1,4 @@
-/**
- * MIT License
- * Copyright (c) 2025 ProjectMobius contributors
- * Nicholas R. Harding and Peter Thompson
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- *      The above copyright notice and this permission notice shall be included in
- *      all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
- */
-
-
+// Copyright Epic Games, Inc. All Rights Reserved.
 using UnrealBuildTool;
 using System.Collections.Generic;
 


### PR DESCRIPTION
## Summary
- remove MIT license comments from game source files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684103912e588325a1fc594104b3a7e0