### PR TITLE
Document pkg build option for Node server

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -80,6 +80,10 @@ For more information on how to comply with Qt’s LGPL requirements, see:
 
 All JavaScript source files in this folder (e.g. `MobiusServer.js`, `package.json`, any utility `.js` modules) that you authored are licensed under the **MIT License** (see Section 5 below). Any third-party npm packages you installed (inside `node_modules/`) must be used in accordance with their own respective licenses—refer to each package’s license inside `node_modules/<package>/LICENSE` when you redistribute.
 
+If you compile the server into a standalone executable you may use the **pkg**
+tool (MIT License). Its repository is <https://github.com/vercel/pkg>. A copy of
+pkg's MIT license text is provided in `ThirdParty/LICENSE.pkg`.
+
 ---
 
 ## 4. Third-Party Libraries & Assets

--- a/README.md
+++ b/README.md
@@ -153,3 +153,16 @@ Copies of their respective license texts are included in the following folders:
 - `Source/Visualization/ThirdParty/OpenCV/LICENSE`
 
 Additional licensing details can be found in [LICENSE.md](LICENSE.md).
+
+## Node.js Server
+
+The WebSocket server under `UnrealFolder/ProjectMobius/Tools/NodeJS/` requires
+**Node.js 16** or newer. It can be compiled into a standalone executable using
+[vercel/pkg](https://github.com/vercel/pkg). A typical build command is:
+
+```bash
+npx pkg MobiusServer.js
+```
+
+The resulting binary can be distributed without requiring Node.js on the target
+machine.

--- a/ThirdParty/LICENSE.pkg
+++ b/ThirdParty/LICENSE.pkg
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- note how to build the Node.js server with vercel/pkg
- list pkg as a build-time dependency in the license
- include the pkg MIT license text

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841178b43808325afd0a6212f9284c3