### PR TITLE
Convert FRunnableThread pointers to TUniquePtr

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/MobiusCore/Private/AsyncAssimpMeshLoader.cpp
+++ b/UnrealFolder/ProjectMobius/Source/MobiusCore/Private/AsyncAssimpMeshLoader.cpp
@@ -112,23 +112,27 @@ FAssimpMeshLoaderRunnable::FAssimpMeshLoaderRunnable(const FString InPathToMesh)
 	bIsWktExtension = PathToMesh.EndsWith(TEXT(".wkt"), ESearchCase::IgnoreCase);
 	
 
-	// Create the thread -- The thread priority is set to TPri_Normal this may need to be adjusted based on the application
-	Thread = FRunnableThread::Create(this, TEXT("FAssimpMeshLoaderRunnable"), 0, TPri_Normal);
+       // Create the thread -- The thread priority is set to TPri_Normal this may need to be adjusted based on the application
+       Thread.Reset(FRunnableThread::Create(this, TEXT("FAssimpMeshLoaderRunnable"), 0, TPri_Normal));
 }
 
 FAssimpMeshLoaderRunnable::~FAssimpMeshLoaderRunnable()
 {
-	// if the thread is still running, stop it
-	if (Thread != nullptr)
-	{
-		Thread->Kill(true);
-		delete Thread;
-	}
+       // if the thread is still running, stop it
+       if (Thread.IsValid())
+       {
+               Thread->Kill(true);
+               Thread.Reset();
+       }
 }
 
 uint32 FAssimpMeshLoaderRunnable::Run()
 {
-	if (bIsWktExtension)
+       if (!Thread.IsValid())
+       {
+               return 0;
+       }
+       if (bIsWktExtension)
 	{
 		ProcessMeshFromString();
 	}

--- a/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/AsyncAssimpMeshLoader.h
+++ b/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/AsyncAssimpMeshLoader.h
@@ -89,8 +89,8 @@ public:
 	FOnLoadMeshDataComplete OnLoadMeshDataComplete;
 
 protected:
-	/** Pointer to a thread */
-	FRunnableThread* Thread = nullptr;
+       /** Pointer to a thread */
+       TUniquePtr<FRunnableThread> Thread;
 
 	/** Bool to tell when the thread should stop */
 	bool bShouldStop = false;

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/MassProcessor/Representation/OLD_AgentRepProcessor.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/MassProcessor/Representation/OLD_AgentRepProcessor.cpp
@@ -438,16 +438,16 @@ void UAgentRepProcessor::UpdateCustomDataForISMComp(UInstancedStaticMeshComponen
 FRunnableRepresentationProcessorOLD::FRunnableRepresentationProcessorOLD(FEntityInfoFragment* InEntityInfo,
                                                                    AAgentRepresentationActorISM* InAgentRepresentationActor)
 {
-	Thread = FRunnableThread::Create(this, TEXT("UpdateRepresentationISM"));
+       Thread.Reset(FRunnableThread::Create(this, TEXT("UpdateRepresentationISM")));
 }
 
 FRunnableRepresentationProcessorOLD::~FRunnableRepresentationProcessorOLD()
 {
-	if (Thread)
-	{
-		Thread->Kill();
-		delete Thread;
-	}
+       if (Thread.IsValid())
+       {
+               Thread->Kill();
+               Thread.Reset();
+       }
 }
 
 bool FRunnableRepresentationProcessorOLD::Init()
@@ -457,7 +457,11 @@ bool FRunnableRepresentationProcessorOLD::Init()
 
 uint32 FRunnableRepresentationProcessorOLD::Run()
 {
-	UE_LOG(LogTemp, Display, TEXT("FRunnableRepresentationProcessor::Running")); // check not running
+       if (!Thread.IsValid())
+       {
+               return 0;
+       }
+       UE_LOG(LogTemp, Display, TEXT("FRunnableRepresentationProcessor::Running")); // check not running
 	// test log
 	// get the entities location and rotation
 	FVector Location = EntityInfo->CurrentLocation;

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
@@ -413,23 +413,27 @@ FJsonDataRunnable::FJsonDataRunnable(FString InJsonDataFile)
 
 	
 	
-	// Create the thread -- The thread priority is set to TPri_Normal this may need to be adjusted based on the application
-	Thread = FRunnableThread::Create(this, TEXT("FJsonDataRunnable"), 0, TPri_Normal);
+       // Create the thread -- The thread priority is set to TPri_Normal this may need to be adjusted based on the application
+       Thread.Reset(FRunnableThread::Create(this, TEXT("FJsonDataRunnable"), 0, TPri_Normal));
 }
 
 FJsonDataRunnable::~FJsonDataRunnable()
 {
-	// if the thread is still running, stop it
-	if (Thread != nullptr)
-	{
-		Thread->Kill(true);
-		delete Thread;
-	}
+       // if the thread is still running, stop it
+       if (Thread.IsValid())
+       {
+               Thread->Kill(true);
+               Thread.Reset();
+       }
 }
 
 uint32 FJsonDataRunnable:: Run()
 {
-	bIsRunning = true;
+       if (!Thread.IsValid())
+       {
+               return 0;
+       }
+       bIsRunning = true;
 	// Broadcast the current percentage of the data loaded
 	AsyncTask(ENamedThreads::GameThread, [this]()
 	{

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/MassAI/MassProcessor/Representation/OLD_AgentRepProcessor.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/MassAI/MassProcessor/Representation/OLD_AgentRepProcessor.h
@@ -168,7 +168,7 @@ public:
 	FRunnableRepresentationProcessorOLD(FEntityInfoFragment* InEntityInfo, class AAgentRepresentationActorISM* InAgentRepresentationActor);
 	virtual ~FRunnableRepresentationProcessorOLD() override;
 
-	FRunnableThread* Thread;
+       TUniquePtr<FRunnableThread> Thread;
 	FEntityInfoFragment* EntityInfo;
 	class AAgentRepresentationActorISM* AgentRepresentationActor;
 	virtual bool Init() override;

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/MassAI/SubSystems/AgentDataSubsystem.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/MassAI/SubSystems/AgentDataSubsystem.h
@@ -263,8 +263,8 @@ public:
 	bool bIsRunning = false; // Flag to indicate if the thread is running
 	
 protected:
-	/** Pointer to a thread */
-	FRunnableThread* Thread = nullptr;
+       /** Pointer to a thread */
+       TUniquePtr<FRunnableThread> Thread;
 
 	FString JsonFilePath = FString();
 


### PR DESCRIPTION
## Summary
- manage worker threads with `TUniquePtr` instead of raw pointers
- reset thread pointers in destructors
- guard `Run` methods if thread creation fails

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848f33631148325863b367e308c50a9