### PR TITLE
Refactor mesh transform with matrices

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/AsyncAssimpMeshLoader.h
+++ b/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/AsyncAssimpMeshLoader.h
@@ -141,9 +141,12 @@ protected:
 	 * 
 	 */
 	static FRotator GetMeshRotation(int32 AxisUpOrientation, int32 AxisUpSign, int32 AxisForwardOrientation = 0, int32 AxisForwardSign = 0);// todo see if forward is needed
-	FVector TransformNormal(const FVector& InNormal, int32 AxisUpOrientation, int32 AxisForwardOrientation,
-	                        int32 AxisForwardSign, int32 AxisUpSign);
+       FVector TransformNormal(const FVector& InNormal, int32 AxisUpOrientation, int32 AxisForwardOrientation,
+                               int32 AxisForwardSign, int32 AxisUpSign);
 
-	static void TransformMeshMatrix(FVector& InVector, int32 AxisUpOrientation, int32 AxisUpSign, int32 AxisForwardOrientation = 0, int32 AxisForwardSign = 0);
+       static FMatrix BuildTransformMatrix(int32 AxisUpOrientation, int32 AxisUpSign,
+                                           int32 AxisForwardOrientation = 0, int32 AxisForwardSign = 0);
+
+       static void TransformMeshMatrix(FVector& InVector, const FMatrix& TransformMatrix);
 };
 


### PR DESCRIPTION
## Summary
- simplify `TransformMeshMatrix` using a matrix-based approach
- compute a transformation matrix based on axis metadata
- apply the matrix to both vertices and normals
- update `ProcessMeshFromFile` and `ProcessMeshFromString` to use the matrix version

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848f36ffb148325a6e00eb5bd995cb0