### PR TITLE
Add earcut.hpp to README library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ This repository provides everything needed to build, run, and package the comple
 - **Bundled Third-Party Libraries & Assets**  
   - **HDF5** for large-scale data logging.  
   - **Assimp** for importing Blender models into Unreal.  
-  - **OpenCV** for texture processing (e.g., Gaussian blur).  
+  - **OpenCV** for texture processing (e.g., Gaussian blur).
+  - **Earcut.hpp** for polygon triangulation (header-only, ISC license).
   - **Blender Models** (exported `.fbx` under `ImportedOpenSourceAssets/`) for environment and agent meshes.
 
 ---


### PR DESCRIPTION
## Summary
- document earcut.hpp in the list of bundled libraries

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b4b3be1f88325aca6eb2ac84677ba