### PR TITLE
Add delegate cleanup in MobiusController

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.cpp
@@ -35,7 +35,7 @@ AMobiusController::AMobiusController()
 
 void AMobiusController::BeginPlay()
 {
-	Super::BeginPlay();
+        Super::BeginPlay();
 
 	// Setup cursor and input mode
 	FInputModeGameAndUI InputMode;
@@ -48,8 +48,24 @@ void AMobiusController::BeginPlay()
 	
 	GetScreenshotRequiredSubsystemsAndData();
 
-	// Bind to the screenshot request captured delegate
-	UGameViewportClient::OnScreenshotCaptured().AddUObject(this, &AMobiusController::OnScreenShotCaptured);
+        // Bind to the screenshot request captured delegate
+        UGameViewportClient::OnScreenshotCaptured().AddUObject(this, &AMobiusController::OnScreenShotCaptured);
+}
+
+void AMobiusController::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+        // Unbind delegates bound in BeginPlay / initialization
+        UGameViewportClient::OnScreenshotCaptured().RemoveAll(this);
+
+        if (GetWorld())
+        {
+                if (UProjectMobiusGameInstance* MobiusGameInstance = Cast<UProjectMobiusGameInstance>(GetWorld()->GetGameInstance()))
+                {
+                        MobiusGameInstance->OnPedestrianVectorFileChanged.RemoveDynamic(this, &AMobiusController::UpdatePedestrianVectorFilePath);
+                }
+        }
+
+        Super::EndPlay(EndPlayReason);
 }
 
 void AMobiusController::GetScreenshotRequiredSubsystemsAndData()

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.h
@@ -43,7 +43,10 @@ public:
 	/**
 	 * Override the BeginPlay method to set the default behavior of the controller
 	 */
-	virtual void BeginPlay() override;
+        virtual void BeginPlay() override;
+
+        /** Override EndPlay to clean up bound delegates */
+        virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 	
 	/** Get the required subsystems to create a screenshot */
 	void GetScreenshotRequiredSubsystemsAndData();


### PR DESCRIPTION
## Summary
- override `EndPlay` in `AMobiusController`
- remove screenshot captured handler in `EndPlay`
- unbind game instance delegate on shutdown

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684bbbd354a48325a7e6b41b962768f8