### PR TITLE
Unbind SimulationPlayBar delegates

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Widgets/Simulation/SimulationPlayBar.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Widgets/Simulation/SimulationPlayBar.cpp
@@ -102,11 +102,43 @@ void USimulationPlayBar::NativeTick(const FGeometry& MyGeometry, float InDeltaTi
 
 void USimulationPlayBar::SynchronizeProperties()
 {
-	Super::SynchronizeProperties();
+        Super::SynchronizeProperties();
 
 	// Assign the style assets
-	AssignStyleAssets();
-	
+        AssignStyleAssets();
+
+}
+
+void USimulationPlayBar::NativeDestruct()
+{
+        Super::NativeDestruct();
+
+        // Unbind delegates from the time dilation subsystem
+        if (TimeDilationSubsystem)
+        {
+                TimeDilationSubsystem->OnNewCurrentTime.RemoveDynamic(this, &USimulationPlayBar::UpdateCurrentTime);
+                TimeDilationSubsystem->OnNewMaxTime.RemoveDynamic(this, &USimulationPlayBar::UpdateMaxTime);
+                TimeDilationSubsystem->OnNewTimeBetweenData.RemoveDynamic(this, &USimulationPlayBar::UpdatePlayBarStepSize);
+        }
+
+        // Unbind button delegates
+        if (PlayPauseButton)
+        {
+                PlayPauseButton->OnClicked.RemoveDynamic(this, &USimulationPlayBar::OnPlayPauseButtonClicked);
+        }
+
+        if (PlaybackSlider)
+        {
+                PlaybackSlider->OnMouseCaptureBegin.RemoveDynamic(this, &USimulationPlayBar::OnPlaybackSliderCaptureBegin);
+                PlaybackSlider->OnMouseCaptureEnd.RemoveDynamic(this, &USimulationPlayBar::OnPlaybackSliderCaptureEnd);
+        }
+
+        // Unbind game instance delegates
+        if (UProjectMobiusGameInstance* ProjectMobiusGameInstance = Cast<UProjectMobiusGameInstance>(GetWorld()->GetGameInstance()))
+        {
+                ProjectMobiusGameInstance->OnDataLoading.RemoveDynamic(this, &USimulationPlayBar::SetPlayButtonEnabled);
+                ProjectMobiusGameInstance->OnPedestrianVectorFileUpdated.RemoveDynamic(this, &USimulationPlayBar::FileChanging);
+        }
 }
 
 void USimulationPlayBar::StartSimulation()

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/Widgets/Simulation/SimulationPlayBar.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/Widgets/Simulation/SimulationPlayBar.h
@@ -45,14 +45,17 @@ class PROJECTMOBIUS_API USimulationPlayBar : public UUserWidget
 #pragma region METHODS
 public:
 	
-	// Constructor 
-	virtual void NativeConstruct() override;
+       // Constructor
+       virtual void NativeConstruct() override;
 
-	// Tick Method for in C++ for the widget
-	virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
+       // Tick Method for in C++ for the widget
+       virtual void NativeTick(const FGeometry& MyGeometry, float InDeltaTime) override;
 
-	// Synchronize
-	virtual void SynchronizeProperties() override;
+       // Synchronize
+       virtual void SynchronizeProperties() override;
+
+       // Destructor
+       virtual void NativeDestruct() override;
 
 protected:
 	/**


### PR DESCRIPTION
## Summary
- add NativeDestruct override for `USimulationPlayBar`
- remove dynamic bindings for TimeDilationSubsystem and GameInstance
- unhook PlayPauseButton and PlaybackSlider delegates

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bbbe3d7588325b5078625984f907e