### PR TITLE
Add cleanup for JsonDataRunnable

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
@@ -93,7 +93,18 @@ void UAgentDataSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 
 void UAgentDataSubsystem::Deinitialize()
 {
-	Super::Deinitialize();
+    if (JsonDataRunnable != nullptr)
+    {
+        if (JsonDataRunnable->bIsRunning)
+        {
+            JsonDataRunnable->Stop();
+        }
+        JsonDataRunnable->Exit();
+        delete JsonDataRunnable;
+        JsonDataRunnable = nullptr;
+    }
+
+    Super::Deinitialize();
 }
 
 void UAgentDataSubsystem::GetJSONDataFile(FString InJsonDataFile)

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/MassEntitySpawnSubsystem.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/MassEntitySpawnSubsystem.cpp
@@ -241,11 +241,13 @@ void UMassEntitySpawnSubsystem::LoadPedestrianData()
 			// unbind current load percent
 			AgentDataSubsystem->JsonDataRunnable->OnLoadSimulationDataProgress.RemoveDynamic(LoadingSubsystem, &ULoadingSubsystem::BroadcastNewLoadPercent);
 		}
-		AgentDataSubsystem->JsonDataRunnable->Exit();
-	}
+                AgentDataSubsystem->JsonDataRunnable->Exit();
+                delete AgentDataSubsystem->JsonDataRunnable;
+                AgentDataSubsystem->JsonDataRunnable = nullptr;
+        }
 
-	// Get the JSON Data File using the FRunnable class to get the data asynchronously
-	AgentDataSubsystem->JsonDataRunnable = new FJsonDataRunnable(JSONDataFile);
+        // Get the JSON Data File using the FRunnable class to get the data asynchronously
+        AgentDataSubsystem->JsonDataRunnable = new FJsonDataRunnable(JSONDataFile);
 	AgentDataSubsystem->JsonDataRunnable->OnLoadSimulationDataComplete.AddDynamic(this, &UMassEntitySpawnSubsystem::BuildPedestrianMovementFragmentData);
 	AgentDataSubsystem->JsonDataRunnable->OnMaxAgentCount.AddDynamic(AgentDataSubsystem, &UAgentDataSubsystem::UpdateMaxAgentCount);
 
@@ -303,8 +305,9 @@ void UMassEntitySpawnSubsystem::BuildPedestrianMovementFragmentData()
 		AgentDataSubsystem->JsonDataRunnable->OnLoadSimulationDataProgress.RemoveDynamic(LoadingSubsystem, &ULoadingSubsystem::BroadcastNewLoadPercent);
 	}
 
-	// Have the thread destroy
-	AgentDataSubsystem->JsonDataRunnable = nullptr;
+        // Have the thread destroy
+        delete AgentDataSubsystem->JsonDataRunnable;
+        AgentDataSubsystem->JsonDataRunnable = nullptr;
 
 	//SimulationFragment.AddMovementSample();
 


### PR DESCRIPTION
## Summary
- ensure JsonDataRunnable threads are properly deleted when replaced
- clean up outstanding threads in `UAgentDataSubsystem::Deinitialize`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684bbbf14c4c8325beb43d75c53bc6a6