### PR TITLE
Subdivide heatmap quads

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/Actors/HeatmapPixelTextureVisualizer.h
+++ b/UnrealFolder/ProjectMobius/Source/MobiusCore/Public/Actors/HeatmapPixelTextureVisualizer.h
@@ -366,8 +366,12 @@ private:
 	TObjectPtr<UWorld> World;
 
 	/** Scaled Circle Size */
-	UPROPERTY()
-	int32 ScaledCircleSize; // TODO: This should be a float value for more precise locations and scale to texture and mesh size
+        UPROPERTY()
+        int32 ScaledCircleSize; // TODO: This should be a float value for more precise locations and scale to texture and mesh size
+
+        /** Number of mesh sections currently generated */
+        UPROPERTY()
+        int32 GeneratedSectionCount = 0;
 	
 #pragma endregion PRIVATE_PROPERTIES_AND_COMPONENTS
 	


### PR DESCRIPTION
## Summary
- subdivide heatmap into quad mesh sections
- track generated sections for clearing
- build each quad asynchronously on the game thread

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f93019950832599c248d8a6999ba9