### PR TITLE
Fix macOS superbuild for Apple Silicon toolchains

### DIFF
--- a/UnrealFolder/ProjectMobius/CMakeLists.txt
+++ b/UnrealFolder/ProjectMobius/CMakeLists.txt
@@ -119,6 +119,15 @@ elseif(APPLE)
     -DCMAKE_OSX_ARCHITECTURES=arm64
     -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0
 
+    # Assimp 5.4.3 predates AppleClang's -Wnontrivial-memcall, which its own
+    # -Werror then turns into a hard failure in SceneCombiner.cpp.
+    -DASSIMP_WARNINGS_AS_ERRORS=OFF
+
+    # Use the bundled contrib/unzip rather than pkg-config's minizip, which on a
+    # machine with an Intel Homebrew prefix resolves to an x86_64 library and
+    # fails to link against this arm64 build.
+    -DASSIMP_BUILD_MINIZIP=ON
+
     # Assimp on UNIX derives ASSIMP_LIB_INSTALL_DIR from CMAKE_INSTALL_LIBDIR.
     # Force libs into lib/Mac to match UE_Assimp expectations.
     -DCMAKE_INSTALL_LIBDIR=lib/Mac
@@ -171,13 +180,10 @@ if(WIN32)
     COMMENT "Staging Assimp DLLs to ${ASSIMP_STAGE_DIR}"
   )
 elseif(APPLE)
-  # Assimp 5.x layouts differ a bit between versions.
-  # Prefer lib/Mac if it exists (old layout), otherwise fall back to lib/.
-  if(EXISTS "${ASSIMP_INST}/lib/Mac")
-    set(ASSIMP_MAC_LIB_DIR "${ASSIMP_INST}/lib/Mac")
-  else()
-    set(ASSIMP_MAC_LIB_DIR "${ASSIMP_INST}/lib")
-  endif()
+  # CMAKE_INSTALL_LIBDIR is forced to lib/Mac above, so the layout is known.
+  # An EXISTS check here would run at configure time, before Assimp is installed,
+  # and on a clean tree would fall back to lib/ and stage a nested Mac/ folder.
+  set(ASSIMP_MAC_LIB_DIR "${ASSIMP_INST}/lib/Mac")
 
   add_custom_command(TARGET assimp_stage POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E rm -rf "${ASSIMP_STAGE_DIR}"


### PR DESCRIPTION
Three failures prevented `cmake --build _superbuild` from completing on macOS (Apple Silicon, Xcode 26 / AppleClang 21). All changes are inside the existing `elseif(APPLE)` branches of `UnrealFolder/ProjectMobius/CMakeLists.txt` — Windows and Linux paths are untouched.

### 1. Assimp `-Werror` vs a newer compiler

```
SceneCombiner.cpp:997:14: error: first argument in call to 'memcpy' is a pointer to
  non-trivially copyable type 'aiFace' [-Werror,-Wnontrivial-memcall]
```

Assimp 5.4.3 predates AppleClang's `-Wnontrivial-memcall`, and its own `ASSIMP_WARNINGS_AS_ERRORS` (default `ON`) turns the new diagnostic into a build failure. Vendored third-party source is left untouched; the option is disabled from the superbuild instead.

### 2. minizip architecture mismatch

```
ld: warning: ignoring file '/usr/local/Cellar/minizip/1.3.1/lib/libminizip.dylib':
  found architecture 'x86_64', required architecture 'arm64'
Undefined symbols for architecture arm64: _unzClose, _unzGetCurrentFileInfo, ...
```

Assimp runs `use_pkgconfig(UNZIP minizip)`, which on a machine with an Intel Homebrew prefix at `/usr/local` resolves to an x86_64 library — unlinkable against the arm64 build this branch pins. `ASSIMP_BUILD_MINIZIP=ON` skips the lookup and compiles the bundled `contrib/unzip`.

### 3. Staging produced a nested directory

`if(EXISTS "${ASSIMP_INST}/lib/Mac")` is evaluated at *configure* time, before Assimp has been built or installed. On a clean tree the directory does not exist yet, so it fell back to `lib/` and `copy_directory` staged `Plugins/UE4_Assimp/Binaries/Mac/Mac/` — one level too deep. The same branch already forces `CMAKE_INSTALL_LIBDIR=lib/Mac`, so the layout is known and the check was removable.

This one is latent rather than fatal: `UE_AssimpLibrary.Build.cs` reads from `assimp/lib/Mac`, not `Binaries/Mac`, so the editor build succeeds either way. It would surface at packaging time.

## Verification

- Full superbuild completes, exit 0. Assimp and HDF5 both produced as `arm64` (`lipo -archs`), staged flat into `Plugins/UE4_Assimp/Binaries/Mac/`.
- `ProjectMobiusEditor Mac Development` builds against UE 5.5.4 — 191/191 actions, exit 0 — and links the resulting Assimp dylib.
- The editor then launches and loads an HDF5 simulation successfully.

Not tested on Windows or Linux; those code paths are unmodified.

## Note for macOS builders

Two further things are needed on a current macOS, deliberately **not** included here since they are environment rather than repo concerns:

- UE 5.5 caps Xcode at `16.9.0` in `Engine/Config/Apple/Apple_SDK.json`. With Xcode 26 installed, UBT reports `Platform Mac is not a valid platform to build`.
- Xcode 26 ships the Metal shader compiler as a separate component: `xcodebuild -downloadComponent MetalToolchain`.