### PR TITLE
Load embedded geometry when an HDF5 agent file is selected

### DIFF
--- a/UnrealFolder/ProjectMobius/Plugins/Hdf5DataPlugin/Source/Hdf5DataPlugin/Private/Hdf5SimulationReader.cpp
+++ b/UnrealFolder/ProjectMobius/Plugins/Hdf5DataPlugin/Source/Hdf5DataPlugin/Private/Hdf5SimulationReader.cpp
@@ -23,8 +23,25 @@
 
 #include "Hdf5SimulationReader.h"
 #include "Misc/Paths.h"
+#include "Misc/ScopeLock.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LogHdf5SimulationReader, Log, All);
+
+namespace
+{
+	/**
+	 * The bundled HDF5 library is built without thread safety (Threadsafety: OFF in
+	 * libhdf5.settings), so no two threads may execute HDF5 code concurrently.
+	 * Geometry and trajectory loading both read the same .h5 from different threads,
+	 * so every public reader method serializes on this process-wide lock.
+	 * The lock is recursive on all UE platforms, so public methods may call each other.
+	 */
+	FCriticalSection& GetHdf5LibraryLock()
+	{
+		static FCriticalSection Hdf5LibraryLock;
+		return Hdf5LibraryLock;
+	}
+}
 
 FHdf5SimulationReader::FHdf5SimulationReader()
 {
@@ -37,6 +54,8 @@ FHdf5SimulationReader::~FHdf5SimulationReader()
 
 bool FHdf5SimulationReader::OpenFile(const FString& FilePath)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	// Close any previously open file
 	CloseFile();
 
@@ -58,7 +77,8 @@ bool FHdf5SimulationReader::OpenFile(const FString& FilePath)
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("Failed to open HDF5 file: %s"), *FilePath);
-		H5close();
+		// Do not call H5close() here: it tears down the HDF5 library process-wide,
+		// crashing any other reader that is mid-operation.
 		return false;
 	}
 
@@ -111,10 +131,13 @@ bool FHdf5SimulationReader::OpenFile(const FString& FilePath)
 
 void FHdf5SimulationReader::CloseFile()
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId >= 0)
 	{
 		H5Fclose(FileId);
-		H5close();
+		// Deliberately no H5close(): that shuts down the HDF5 library for the whole
+		// process, not just this file, and other readers may still be active.
 		FileId = -1;
 		DetectedFormat = EHdf5FormatType::Unknown;
 		TimestepCount = 0;
@@ -276,6 +299,8 @@ bool FHdf5SimulationReader::ReadStringAttribute(hid_t GroupId, const char* AttrN
 
 bool FHdf5SimulationReader::ReadMetadata(FHdf5SimulationMetadata& OutMetadata)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -320,6 +345,8 @@ bool FHdf5SimulationReader::ReadMetadata(FHdf5SimulationMetadata& OutMetadata)
 
 bool FHdf5SimulationReader::ReadEntities(TArray<FHdf5EntityData>& OutEntities)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -417,6 +444,8 @@ bool FHdf5SimulationReader::ReadEntities(TArray<FHdf5EntityData>& OutEntities)
 
 bool FHdf5SimulationReader::ReadTimesteps(TArray<float>& OutTimesteps)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -453,6 +482,8 @@ bool FHdf5SimulationReader::ReadTimesteps(TArray<float>& OutTimesteps)
 
 bool FHdf5SimulationReader::ReadSamplesPerTimestep(TArray<int32>& OutSamplesPerTimestep)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -496,6 +527,8 @@ bool FHdf5SimulationReader::ReadSamplesPerTimestep(TArray<int32>& OutSamplesPerT
 
 bool FHdf5SimulationReader::ReadAllSamples(TArray<FHdf5SampleData>& OutSamples, bool* OutHasRotationField, bool* OutHasSpeedField)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -608,6 +641,8 @@ bool FHdf5SimulationReader::ReadAllSamples(TArray<FHdf5SampleData>& OutSamples, 
 
 bool FHdf5SimulationReader::ReadSamplesForTimestepRange(int32 StartTimestep, int32 EndTimestep, TArray<FHdf5SampleData>& OutSamples)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -718,6 +753,8 @@ EHdf5FormatType FHdf5SimulationReader::DetectFormat(const FString& FilePath)
 		return EHdf5FormatType::Unknown;
 	}
 
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	FTCHARToUTF8 FilePathUtf8(*FilePath);
 
 	// Check if it's a valid HDF5 file
@@ -731,7 +768,6 @@ EHdf5FormatType FHdf5SimulationReader::DetectFormat(const FString& FilePath)
 	hid_t TempFileId = H5Fopen(FilePathUtf8.Get(), H5F_ACC_RDONLY, H5P_DEFAULT);
 	if (TempFileId < 0)
 	{
-		H5close();
 		return EHdf5FormatType::Unknown;
 	}
 
@@ -750,7 +786,6 @@ EHdf5FormatType FHdf5SimulationReader::DetectFormat(const FString& FilePath)
 	}
 
 	H5Fclose(TempFileId);
-	H5close();
 
 	return Result;
 }
@@ -759,6 +794,8 @@ EHdf5FormatType FHdf5SimulationReader::DetectFormat(const FString& FilePath)
 
 bool FHdf5SimulationReader::ReadJuelichMetadata(FHdf5JuelichMetadata& OutMetadata)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -845,6 +882,8 @@ bool FHdf5SimulationReader::ReadJuelichMetadata(FHdf5JuelichMetadata& OutMetadat
 
 bool FHdf5SimulationReader::ReadJuelichTrajectories(TArray<FHdf5JuelichTrajectoryRecord>& OutRecords)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));
@@ -924,6 +963,8 @@ bool FHdf5SimulationReader::ReadJuelichTrajectories(TArray<FHdf5JuelichTrajector
 
 bool FHdf5SimulationReader::ReadWktGeometry(FString& OutWktGeometry)
 {
+	FScopeLock Hdf5Guard(&GetHdf5LibraryLock());
+
 	if (FileId < 0)
 	{
 		UE_LOG(LogHdf5SimulationReader, Error, TEXT("No file is open"));

--- a/UnrealFolder/ProjectMobius/Source/MobiusCore/Private/Interfaces/ProjectMobiusInterface.cpp
+++ b/UnrealFolder/ProjectMobius/Source/MobiusCore/Private/Interfaces/ProjectMobiusInterface.cpp
@@ -25,8 +25,47 @@
 #include "Interfaces/ProjectMobiusInterface.h"
 #include "Engine/GameInstance.h"
 #include "GameInstances/ProjectMobiusGameInstance.h"
+#include "Hdf5SimulationReader.h"
+#include "Misc/Paths.h"
 
 // Add default functionality here for any IProjectMobiusInterface functions that are not pure virtual.
+
+namespace
+{
+	/**
+	 * HDF5 simulation files can carry the scene geometry alongside the trajectories in the
+	 * root "wkt_geometry" attribute. When such a file is selected as the pedestrian data
+	 * source, adopt it as the geometry source too so a single selection loads both.
+	 * @param GameInst - Mobius game instance to update
+	 * @param DataPath - Full path of the newly selected pedestrian data file
+	 */
+	void AdoptEmbeddedGeometrySource(UProjectMobiusGameInstance* GameInst, const FString& DataPath)
+	{
+		if (!GameInst || !DataPath.EndsWith(TEXT(".h5"), ESearchCase::IgnoreCase))
+		{
+			return;
+		}
+
+		FHdf5SimulationReader Reader;
+		if (!Reader.OpenFile(DataPath))
+		{
+			return;
+		}
+
+		FString WktGeometry;
+		const bool bHasGeometry = Reader.ReadWktGeometry(WktGeometry) && !WktGeometry.IsEmpty();
+		Reader.CloseFile();
+
+		if (!bHasGeometry)
+		{
+			UE_LOG(LogTemp, Log, TEXT("No embedded geometry in %s, geometry selection left unchanged"), *DataPath);
+			return;
+		}
+
+		GameInst->SetSimulationMeshFilePath(DataPath);
+		GameInst->SetSimulationMeshFileName(FPaths::GetCleanFilename(DataPath));
+	}
+}
 
 UProjectMobiusGameInstance* IProjectMobiusInterface::GetMobiusGameInstance(UWorld* World)
 {
@@ -111,6 +150,9 @@ void IProjectMobiusInterface::UpdateMobiusGameInstancePedestrianData(UWorld* Wor
 	
 	// Set the pedestrian data file name
 	MobiusGameInst->SetPedestrianDataFileName(FPaths::GetCleanFilename(CompleteDataPath));
+
+	// HDF5 files can embed the geometry, load it from the same file
+	AdoptEmbeddedGeometrySource(MobiusGameInst, CompleteDataPath);
 }
 
 void IProjectMobiusInterface::GetMobiusGameInstanceMeshDataFile(UWorld* World, FString& OutCompleteDataPath,

--- a/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Private/UI/LoadSave/LoadAgentDataWidget.cpp
+++ b/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Private/UI/LoadSave/LoadAgentDataWidget.cpp
@@ -132,7 +132,7 @@ void ULoadAgentDataWidget::DialogClosed(const FString& AgentFilePath, const FStr
 			Feedback->ReportError(
 				FText::FromString("Invalid Agent Data File"),
 				FText::FromString("Unsupported agent data file type selected."),
-				FText::FromString("Supported types: .json"),
+				FText::FromString("Supported types: .json, .h5"),
 				FText::FromString("Load Agent Data"));
 		}
 		UE_LOG(LogTemp, Warning, TEXT("The file dialog was canceled or an error occurred"));

--- a/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Private/UI/LoadSave/LoadMeshWidget.cpp
+++ b/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Private/UI/LoadSave/LoadMeshWidget.cpp
@@ -25,11 +25,33 @@
 #include "UI/LoadSave/LoadMeshWidget.h"
 #include "Subsystems/NativeFileDialogSubsystem.h"
 #include "Subsystems/MobiusUserFeedbackSubsystem.h"
+#include "GameInstances/ProjectMobiusGameInstance.h"
 
 void ULoadMeshWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
+	if (UProjectMobiusGameInstance* MobiusGameInst = IProjectMobiusInterface::GetMobiusGameInstance(GetWorld()))
+	{
+		MobiusGameInst->OnMeshFileChanged.AddUniqueDynamic(this, &ULoadMeshWidget::OnGameInstanceMeshFileChanged);
+	}
+}
+
+void ULoadMeshWidget::NativeDestruct()
+{
+	if (UProjectMobiusGameInstance* MobiusGameInst = IProjectMobiusInterface::GetMobiusGameInstance(GetWorld()))
+	{
+		MobiusGameInst->OnMeshFileChanged.RemoveDynamic(this, &ULoadMeshWidget::OnGameInstanceMeshFileChanged);
+	}
+
+	Super::NativeDestruct();
+}
+
+void ULoadMeshWidget::OnGameInstanceMeshFileChanged()
+{
+	// Pull the new path out of the game instance and refresh the text block
+	GetMobiusGameInstanceData();
+	UpdateFileTextBlockTexts();
 }
 
 void ULoadMeshWidget::OnSelectFileButtonClicked()
@@ -132,7 +154,7 @@ void ULoadMeshWidget::DialogClosed(const FString& AgentFilePath, const FString& 
 			Feedback->ReportError(
 				FText::FromString("Invalid Mesh File"),
 				FText::FromString("Unsupported mesh file type selected."),
-				FText::FromString("Supported types: .fbx, .obj, .udatasmith, .ifc, .wkt"),
+				FText::FromString("Supported types: .fbx, .obj, .udatasmith, .ifc, .wkt, .h5"),
 				FText::FromString("Load Mesh"));
 		}
 		UE_LOG(LogTemp, Warning, TEXT("The file dialog was canceled or an error occurred"));

--- a/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Public/UI/LoadSave/LoadMeshWidget.h
+++ b/UnrealFolder/ProjectMobius/Source/MobiusWidgets/Public/UI/LoadSave/LoadMeshWidget.h
@@ -41,6 +41,8 @@ public:
 #pragma region PUBLIC_METHODS
 	// Constructor 
 	virtual void NativeConstruct() override;
+
+	virtual void NativeDestruct() override;
 	
 	/**
 	 * Method to call when the SelectFileButton is clicked
@@ -66,6 +68,13 @@ public:
 	/** Handler for file dialog errors. Displays error popup to user. */
 	UFUNCTION()
 	void OnDialogError(const FString& ErrorTitle, const FString& ErrorMessage);
+
+	/**
+	 * Refresh the displayed path when the geometry file is changed elsewhere, e.g. when an
+	 * HDF5 pedestrian data file supplies its own embedded geometry.
+	 */
+	UFUNCTION()
+	void OnGameInstanceMeshFileChanged();
 #pragma endregion PUBLIC_METHODS
 
 #pragma endregion METHODS


### PR DESCRIPTION
Closes #11.

> ⚠️ **Stacked on #13** (`fix-hdf5-library-teardown`) and includes its commit. Please merge #13 first; this diff will shrink to a single commit afterwards. The dependency is not cosmetic — see "Why the ordering matters" below.

## Problem

HDF5 simulation files carry the scene geometry in the root `wkt_geometry` attribute, but selecting one as **Pedestrian Vectors** loaded only the trajectories. The geometry required browsing a second time and picking *the same file* in the **Geometry** slot. In the reporter's screenshot on #11 the Geometry field still reads "Click Browse to choose file" — agents render, the arena does not.

`RuntimeMeshBuilder::UpdateMeshFileName` reads `GetSimulationMeshFilePath()`, which only an explicit mesh pick sets, and nothing inspected the agent file for embedded geometry.

The UI reinforced the confusion: `LoadMeshWidget.cpp` advertised `.fbx, .obj, .udatasmith, .ifc, .wkt` while the file dialog (`NativeFileDialogSubsystem`) and the loader (`AsyncAssimpMeshLoader.cpp`, which routes `.h5` to `ProcessMeshFromString`) both already accepted `.h5`.

Note this is **not** platform-specific — the same double selection was required on Windows.

## Change

- `AdoptEmbeddedGeometrySource` in `ProjectMobiusInterface.cpp`: when the selected pedestrian data file is a `.h5` that contains `wkt_geometry`, set the simulation mesh path to the same file. `SetSimulationMeshFilePath` already broadcasts `OnMeshFileChanged`, which `RuntimeMeshBuilder` listens to, so no further wiring is needed. Files without the attribute are left alone and log a line saying so.
- `ULoadMeshWidget` binds `OnMeshFileChanged` so its path display reflects the adopted file instead of remaining on the browse prompt. Unbound in `NativeDestruct`; `AddUniqueDynamic` to survive re-construction.
- Help texts in both load widgets now list `.h5`, matching what the dialog and loader already accept.

The probe is cheap: `OpenFile` on a Juelich file is `H5Fopen` + `H5Lexists` + a dataspace-dims read — metadata only, no bulk scan.

## Why the ordering matters

This feature is what makes two threads touch HDF5 at once — the geometry loader (`FAssimpMeshLoaderRunnable`) and the trajectory loader (`FProcessSimulationDataRunnable`) now both open the same file. Without #13 that is a reliable SIGSEGV, because the bundled HDF5 is built `Threadsafety: OFF` and `CloseFile()` used to call `H5close()`, tearing the library down process-wide. Merging this alone would turn a latent crash into a deterministic one.

## Verification

macOS, UE 5.5.4, Juelich file with 516 entities / 7.17M trajectory records and a 14-ring polygon (outer boundary, one central hole, 12 obstacles):

```
LogHdf5SimulationReader: Read WKT geometry (83632 chars)
LogHdf5SimulationReader: Converted Juelich to Mobius: 516 entities, 7172623 samples
LogTemp: Display: UPedestrianInitializeMOP::Execute()
```

One selection, geometry and trajectories both loaded, arena renders with agents moving inside it.

## Unrelated issue noticed while testing

The mesh emitter logs `Detected 56 degenerate triangles ... will be dropped` for this file. WKT rings are closed (first point == last), and `AsyncAssimpMeshLoader.cpp` emits 4 wall faces per ring segment including the duplicated closing one — exactly 4 × 14 rings. Harmless today since UE drops them, but the wall emitter assumes open rings. Not addressed here.