### PR TITLE
Drop editor-cosmetic plugins from the project requirements

### DIFF
--- a/UnrealFolder/ProjectMobius/ProjectMobius.uproject
+++ b/UnrealFolder/ProjectMobius/ProjectMobius.uproject
@@ -118,16 +118,6 @@
 			]
 		},
 		{
-			"Name": "ElectronicNodes",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/5cb2a394d0c04e73891762be4cbd7216"
-		},
-		{
-			"Name": "DarkerNodes",
-			"Enabled": true,
-			"MarketplaceURL": "com.epicgames.launcher://ue/marketplace/content/4b3441f0228a40ec9ca986489a5bd682"
-		},
-		{
 			"Name": "AnimToTexture",
 			"Enabled": true
 		},


### PR DESCRIPTION
A fresh clone cannot be built on a machine that does not already have two Marketplace plugins installed. UnrealBuildTool stops before compiling anything:

```
Unable to find plugin 'ElectronicNodes' (referenced via ProjectMobius.uproject).
Install it and try again, or remove it from the required plugin list.
```

Removing that one, the next run fails identically on `DarkerNodes`.

## Why these two are different from the other 20

`ElectronicNodes` changes how Blueprint wires are drawn; `DarkerNodes` restyles the editor UI. They are Blueprint-graph *appearance* plugins — no runtime code, no build step, nothing the project depends on. Every other entry in the plugin list (Mass*, Datasmith*, OpenCV, Hdf5DataPlugin, …) is load-bearing.

They are also the only two plugins in the project that are undocumented: no mention in `README.md`, and no entry in `ASSET_LICENSES.md`, even though the project otherwise tracks the licensing of everything it depends on.

Listing them with `"Enabled": true` makes them **required**, so a per-developer editor preference has become a hard build dependency for every contributor.

## Change

Remove both entries. Editor appearance belongs in each developer's engine-level plugin settings (Edit → Plugins, which persists per engine install, not per project), so anyone who wants them can keep using them with no effect on anyone else.

## Alternative, if you would rather keep them visible in the project

`FPluginReferenceDescriptor` supports an optional flag — `Engine/Source/Runtime/Projects/Public/PluginReferenceDescriptor.h`:

```cpp
/** Whether this plugin is optional, and the game should silently ignore it not being present */
bool bOptional;
```

So the entries could instead be restored as:

```json
{
    "Name": "ElectronicNodes",
    "Enabled": true,
    "Optional": true,
    "MarketplaceURL": "..."
}
```

That keeps them enabled for developers who have them and silently skips them for everyone else. Happy to switch this PR to that form if you prefer — I went with removal because these are personal editor preferences rather than project configuration.

## Verification

With both entries removed, `ProjectMobiusEditor Mac Development` configures and builds from a clean clone with no Marketplace plugins installed. No source, content, or Blueprint changes — the removed plugins have no assets or code referencing them.