### PR TITLE
Fix false "incomplete entity data" warning on time-varying populations

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/AgentDataSubsystem.cpp
@@ -1298,11 +1298,6 @@ void FProcessSimulationDataRunnable::RunHdf5SimDataGatheringLoop(bool bCalculate
 
 	// --- Incomplete data detection ---
 	int32 ActualTimestepCount = MaxTimestepIndex + 1;
-	int32 PeakEntityCount = 0;
-	for (int32 Count : NumOfAgentsPerTimeStep)
-	{
-		PeakEntityCount = FMath::Max(PeakEntityCount, Count);
-	}
 
 	// Timestep mismatch: metadata says more timesteps than we actually loaded
 	if (Hdf5Data.Meta.Duration > 0 && Hdf5Data.Meta.SamplingRate > 0)
@@ -1318,14 +1313,31 @@ void FProcessSimulationDataRunnable::RunHdf5SimDataGatheringLoop(bool bCalculate
 		}
 	}
 
-	// Entity count mismatch: fewer entities observed than metadata declares
-	if (MaxAgents > 0 && PeakEntityCount > 0 && PeakEntityCount < MaxAgents)
+	// Entity coverage: every entity the metadata declares should appear in at least one
+	// timestep. This deliberately does not compare against the busiest timestep, because
+	// agents enter and leave over the course of a simulation, so the peak concurrent count
+	// is legitimately lower than the total number of distinct entities.
+	if (MaxAgents > 0)
 	{
-		ReportAgentDataErrorAnyThread(OwnerSubsystem.Get(),
-			TEXT("Incomplete entity data"),
-			FString::Printf(TEXT("HDF5: peak entity count %d < MaxAgents %d. Some entities may be missing."),
-				PeakEntityCount, MaxAgents),
-			TEXT("AgentDataSubsystem - RunHdf5SimDataGatheringLoop"));
+		TBitArray<> ObservedEntities(false, MaxAgents);
+		int32 ObservedEntityCount = 0;
+		for (const FHdf5SampleData& Sample : Hdf5Data.Samples)
+		{
+			if (ObservedEntities.IsValidIndex(Sample.EntityId) && !ObservedEntities[Sample.EntityId])
+			{
+				ObservedEntities[Sample.EntityId] = true;
+				++ObservedEntityCount;
+			}
+		}
+
+		if (ObservedEntityCount < MaxAgents)
+		{
+			ReportAgentDataErrorAnyThread(OwnerSubsystem.Get(),
+				TEXT("Incomplete entity data"),
+				FString::Printf(TEXT("HDF5: %d of %d entities have no samples. Data may be incomplete."),
+					MaxAgents - ObservedEntityCount, MaxAgents),
+				TEXT("AgentDataSubsystem - RunHdf5SimDataGatheringLoop"));
+		}
 	}
 }
 


### PR DESCRIPTION
Loading a normal pedestrian dataset raises a user-facing error popup claiming data is missing, when nothing is missing:

```
LogHdf5SimulationReader: Converted Juelich to Mobius: 493 entities, 1442486 samples, duration=1198.80s, fps=5.00
LogMobiusUserFeedback: Error: Incomplete entity data: HDF5: peak entity count 386 < MaxAgents 493.
  Some entities may be missing. (AgentDataSubsystem - RunHdf5SimDataGatheringLoop)
```

## Cause

The check compares two quantities that measure different things:

- `MaxAgents` comes from `ConvertJuelichToMobiusFormat` as `SortedIds.Num()` — distinct entity IDs **across the whole run**.
- `PeakEntityCount` is the maximum entries in `NumOfAgentsPerTimeStep` — agents in the **busiest single timestep**.

These are equal only if every agent is present for the entire simulation. In any dataset where agents enter and leave, the peak concurrent count is legitimately lower than the total, and the warning fires.

Verified against the file above by reading the HDF5 directly:

```
unique ids (= MaxAgents):        493
peak concurrent agents:          386
agents present for the whole run:  0 of 493
median lifespan:                3193 of 5993 frames
```

All 493 entities are present in the data. Not one of them spans the full run, so the condition is guaranteed to trigger. It would stay quiet only on a synthetic file where the population never changes.

The spawn path is unaffected — `SpawnMaxPedestrians` uses `GetMaxAgents()`, so 493 MASS entities are created and the ones without samples at a given timestep simply do not render. This is a spurious warning, not a sizing bug.

## Change

Measure the property the check was actually after: how many declared entities have no samples at all.

```cpp
TBitArray<> ObservedEntities(false, MaxAgents);
// ... mark each Sample.EntityId ...
if (ObservedEntityCount < MaxAgents)
    → "HDF5: %d of %d entities have no samples. Data may be incomplete."
```

That still catches genuinely truncated data — an entity declared in metadata but absent from every timestep — while staying quiet on normal pedestrian flow. `PeakEntityCount` and its loop are removed as they now have no other use.

One pass over `Hdf5Data.Samples` with a `TBitArray` sized to `MaxAgents`; negligible against the 1.4M samples already being iterated in this function.

The neighbouring timestep-truncation check is left untouched — it compares like with like and is correct as written.

## Verification

macOS, UE 5.5.4. Compiles clean; the warning no longer fires for the dataset above, whose 493 entities all have samples.