### PR TITLE
Fix agent click-selection never working

### DIFF
--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/Controller/MobiusController.cpp
@@ -29,6 +29,7 @@
 #include "IXRTrackingSystem.h"
 #include "GameInstances/ProjectMobiusGameInstance.h"
 #include "Subsystems/MobiusControllerSubsystem.h"
+#include "MassAI/SubSystems/PedestrianSignalSubsystem.h"
 #include "SubSystems/TimeDilationSubSystem.h"
 #include "Subsystems/MobiusUserFeedbackSubsystem.h"
 #include "Util/FrameGrabberHelper.h"
@@ -109,6 +110,16 @@ void AMobiusController::Tick(float DeltaTime)
 	if (FrameGrabberHelper)
 	{
 		FrameGrabberHelper->Tick(DeltaTime);
+	}
+
+	// Native click-to-select: runs the same trace the BP click path should trigger.
+	// Selecting is a no-op until collisions are activated, so this is safe by default.
+	if (bClickSelectsAgent && WasInputKeyJustPressed(EKeys::LeftMouseButton))
+	{
+		if (UMobiusControllerSubsystem* ControllerSub = GetWorld()->GetSubsystem<UMobiusControllerSubsystem>())
+		{
+			ControllerSub->SelectPedestrianFromMousePosition();
+		}
 	}
 }
 
@@ -498,6 +509,24 @@ void AMobiusController::InterpolateCameraToTransform(const FTransform& TargetTra
 	}
 }
 
+void AMobiusController::MobiusActivateCollisions()
+{
+	if (UPedestrianSignalSubsystem* SignalSub = GetWorld()->GetSubsystem<UPedestrianSignalSubsystem>())
+	{
+		UE_LOG(LogTemp, Display, TEXT("MobiusActivateCollisions: firing CollisionsSettingChanged(1)"));
+		SignalSub->CollisionsSettingChanged(1);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("MobiusActivateCollisions: PedestrianSignalSubsystem not found"));
+	}
+}
+
+void AMobiusController::MobiusToggleClickSelect()
+{
+	bClickSelectsAgent = !bClickSelectsAgent;
+	UE_LOG(LogTemp, Display, TEXT("Native click-select: %s"), bClickSelectsAgent ? TEXT("on") : TEXT("off"));
+}
 
 void AMobiusController::CycleCameraSavePoints()
 {

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SignalProcessors/EnableCollisionSignalProcessor.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SignalProcessors/EnableCollisionSignalProcessor.cpp
@@ -63,7 +63,9 @@ void UDisableCollisionSignalProcessor::Initialize(UObject& Owner)
 {
 	// Subscribe to the signals we want to handle in this processor
 	UMassSignalSubsystem* SignalSubsystem = UWorld::GetSubsystem<UMassSignalSubsystem>(Owner.GetWorld());
-	SubscribeToSignal(*SignalSubsystem, PedestrianDataSignals::Signals::ActivateCollisions);// check that this is needed feels wrong
+	// Only DeactivateCollisions: subscribing to ActivateCollisions as well made this
+	// processor re-disable the entities the enable processor had just enabled, so the
+	// collision capsules never activated and agent selection always missed.
 	SubscribeToSignal(*SignalSubsystem, PedestrianDataSignals::Signals::DeactivateCollisions);
 	Super::Initialize(Owner);
 }

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/PedestrianSignalSubsystem.cpp
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Private/MassAI/SubSystems/PedestrianSignalSubsystem.cpp
@@ -24,7 +24,7 @@ UMassEntitySpawnSubsystem* UPedestrianSignalSubsystem::GetSpawnSubsystem()
 
 void UPedestrianSignalSubsystem::CollisionsSettingChanged(uint8 EnableDisable)
 {
-	UE_LOG(LogTemp, Display, TEXT("Pedestrian CollisionsSettingChanged"));
+	UE_LOG(LogTemp, Display, TEXT("Pedestrian CollisionsSettingChanged value=%d"), EnableDisable);
 	if (EnableDisable == 0)
 	{
 		DeactivateCollisions();

--- a/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/Controller/MobiusController.h
+++ b/UnrealFolder/ProjectMobius/Source/ProjectMobius/Public/Controller/MobiusController.h
@@ -96,6 +96,16 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "MobiusController|Methods|CameraSave")
 	void CycleCameraSavePoints();
 
+	/** Console fallback for the red select-mode button: fires the ActivateCollisions signal. */
+	UFUNCTION(Exec) void MobiusActivateCollisions();
+	/** Toggle the native left-click agent selection (on by default). */
+	UFUNCTION(Exec) void MobiusToggleClickSelect();
+
+private:
+	/** Route plain LMB clicks into the C++ selection trace; the BP click path is unreliable */
+	bool bClickSelectsAgent = true;
+
+public:
 #pragma region PROPERTIES
 	/** Ptr to the Time dialation subsystem to get the current simulation time */
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "MobiusController|Properties")


### PR DESCRIPTION
Agent selection (red select-mode button, then click a pedestrian) never worked on our machines. Root cause:

`UDisableCollisionSignalProcessor::Initialize` subscribes to **both** `ActivateCollisions` and `DeactivateCollisions` — so the same signal that enables the pedestrian hit-capsules immediately re-disables them (`Enabled` tag → `Disabled`) in the same frame. `PedestrianCollisionProcessor` (requires `Enabled`, excludes `Disabled`) then never runs, capsules never track agents, and the selection trace can't hit anything. The existing comment on that line — *"check that this is needed feels wrong"* — was right; this PR drops the wrong subscription.

Also included:
- Native left-click → `SelectPedestrianFromMousePosition()` from the controller tick (the BP click path never reached C++ in our sessions; the call is idempotent if BP also fires it)
- `MobiusActivateCollisions` console fallback for the red button
- `MobiusToggleClickSelect` escape hatch
- Log the value passed to `CollisionsSettingChanged`

Known limitation (pre-existing, unchanged): `ActivateCollisions` silently no-ops if pressed before any agents have spawned — worth queuing the activation, happy to follow up.

Verified on macOS: selection now fills the stats panel and shows the follow indicator (Agent ID, demographics, live speed/position).